### PR TITLE
Improve randomizer usability and styling

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -32,8 +32,13 @@ function App() {
     );
   }, []);
 
-  const applyFilters = ({ types, maxDist }) => {
+  const applyFilters = ({ types, maxDist, location }) => {
     let arr = places.filter(p => types[p.type]);
+    if (location) {
+      arr = arr.filter(p =>
+        p.location.toLowerCase().includes(location.toLowerCase())
+      );
+    }
     if (userLoc && maxDist != null) {
       arr = arr.filter(p => {
         const dist = haversine(userLoc, [
@@ -64,6 +69,15 @@ function App() {
   const handleModify = () => {
     setSelected(null);
   };
+
+  if (!places.length) {
+    return (
+      <div className={styles.container}>
+        <h1>Travel Randomizer (簡單 gaan2daan1)</h1>
+        <p>Loading...</p>
+      </div>
+    );
+  }
 
   return (
     <div className={styles.container}>

--- a/src/App.module.css
+++ b/src/App.module.css
@@ -1,11 +1,16 @@
 /* src/App.module.css */
-.container {
-  max-width: 600px;
-  margin: 2rem auto;
-  font-family: Arial, sans-serif;
-  padding: 0 1rem;
-}
 h1 {
   text-align: center;
   color: #333;
+  margin-bottom: 1rem;
+}
+
+.container {
+  max-width: 600px;
+  margin: 2rem auto;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  padding: 2rem;
+  background: linear-gradient(135deg, #e0f7fa, #ffffff);
+  border-radius: 12px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
 }

--- a/src/components/FilterForm.js
+++ b/src/components/FilterForm.js
@@ -9,6 +9,7 @@ export default function FilterForm({ onSubmit }) {
     sightseeing: true,
   });
   const [maxDist, setMaxDist] = useState("");
+  const [location, setLocation] = useState("");
 
   const handleCheckbox = e => {
     const { name, checked } = e.target;
@@ -17,15 +18,24 @@ export default function FilterForm({ onSubmit }) {
 
   const handleSubmit = e => {
     e.preventDefault();
-    onSubmit({ types, maxDist: maxDist ? parseFloat(maxDist) : null });
+    onSubmit({
+      types,
+      maxDist: maxDist ? parseFloat(maxDist) : null,
+      location,
+    });
   };
 
   return (
     <form className={styles.form} onSubmit={handleSubmit}>
-      <label>Choose location:</label>
-      <select disabled>
-        <option>Hong Kong</option>
-      </select>
+      <label>
+        Location:
+        <input
+          type="text"
+          value={location}
+          onChange={e => setLocation(e.target.value)}
+          placeholder="e.g. Hong Kong"
+        />
+      </label>
       <div className={styles.checkboxGroup}>
         {["eating", "shopping", "sightseeing"].map(t => (
           <label key={t}>

--- a/src/components/FilterForm.module.css
+++ b/src/components/FilterForm.module.css
@@ -6,14 +6,23 @@
   background: #fafafa;
   padding: 1rem;
   border-radius: 8px;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
 }
 .checkboxGroup {
   display: flex;
   gap: 1rem;
 }
+
+input[type="text"],
+input[type="number"],
+select {
+  padding: 0.3rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
 .button {
   padding: 0.5rem 1rem;
-  background: #4caf50;
+  background: #ff5722;
   border: none;
   color: white;
   border-radius: 4px;

--- a/src/components/RandomPlace.js
+++ b/src/components/RandomPlace.js
@@ -21,6 +21,9 @@ export default function RandomPlace({
         <strong>Comment:</strong> {place.comment}
       </div>
       <div className={styles.detail}>
+        <strong>Location:</strong> {place.location}
+      </div>
+      <div className={styles.detail}>
         <strong>Distance:</strong> {distance.toFixed(2)} km
       </div>
       <div className={styles.actions}>

--- a/src/components/RandomPlace.module.css
+++ b/src/components/RandomPlace.module.css
@@ -1,10 +1,10 @@
 /* src/components/RandomPlace.module.css */
 .card {
-  background: #fff;
+  background: linear-gradient(135deg, #ffffff, #e8f5e9);
   border: 1px solid #ddd;
   border-radius: 8px;
   padding: 1rem;
-  box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
 }
 .title {
   font-size: 1.5rem;
@@ -20,7 +20,7 @@
 }
 .button {
   padding: 0.5rem 1rem;
-  background: #2196f3;
+  background: #4caf50;
   border: none;
   color: white;
   border-radius: 4px;
@@ -31,7 +31,7 @@
 }
 .link {
   align-self: center;
-  color: #555;
+  color: #333;
   cursor: pointer;
   text-decoration: underline;
 }


### PR DESCRIPTION
## Summary
- allow editing location filter and pass to App
- filter places by location
- show loading message while data loads
- tweak styling for a more vibrant design
- display location of the chosen place

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68762b06610c832ab75c5a6a8b43f0d8